### PR TITLE
Привязка Figures к сцене и доработка фигур

### DIFF
--- a/Models/Figures/PathFigure.cs
+++ b/Models/Figures/PathFigure.cs
@@ -3,6 +3,7 @@ using Formats;
 using Paint2.ViewModels;
 using Paint2.ViewModels.Interfaces;
 using Paint2.ViewModels.Utils;
+using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
 using Serilog;
 using System;
@@ -10,7 +11,7 @@ using System.Collections.Generic;
 
 namespace Paint2.Models.Figures
 {
-    public abstract class PathFigure : IFigure
+    public abstract class PathFigure : ReactiveObject, IFigure
     {
         public string Name
         {
@@ -41,10 +42,22 @@ namespace Paint2.Models.Figures
         [Reactive] public Geometry Geometry { get; set; }
         public bool IsActive { get; set; }
         public bool IsMirrored { get; set; }
+        public IFigureGraphicProperties? GraphicProperties
+        {
+            get
+            {
+                if (_graphicProperties is null)
+                    return Parent.GraphicProperties;
+                else
+                    return _graphicProperties;
+            }
+            set => this.RaiseAndSetIfChanged(ref _graphicProperties, value);
+        }
 
         protected string name;
         protected Group _parentGroup;
         protected IList<IPathElement> pathElements;
+        protected IFigureGraphicProperties? _graphicProperties;
 
         protected PathFigure(Group parentGroup, Point coordinates)
         {

--- a/Models/Figures/PathFigure.cs
+++ b/Models/Figures/PathFigure.cs
@@ -35,7 +35,7 @@ namespace Paint2.Models.Figures
                     _parentGroup.childObjects.Remove(this);
                     _parentGroup = value;
                     _parentGroup.childObjects.Add(this);
-                    Scene.Current.TriggerHeirarchyRebuild();
+                    Scene.Current.TriggerOnHeirarchyUpdate();
                 }
             }
         }
@@ -68,7 +68,7 @@ namespace Paint2.Models.Figures
             _parentGroup = parentGroup;
             _parentGroup.childObjects.Add(this);
 
-            Scene.Current.TriggerHeirarchyRebuild();
+            Scene.Current.TriggerOnHeirarchyUpdate();
         }
 
         public void Export(IExportSnapshot snapshot)

--- a/Models/Figures/PathFigure.cs
+++ b/Models/Figures/PathFigure.cs
@@ -35,6 +35,7 @@ namespace Paint2.Models.Figures
                     _parentGroup.childObjects.Remove(this);
                     _parentGroup = value;
                     _parentGroup.childObjects.Add(this);
+                    Scene.Current.TriggerHeirarchyRebuild();
                 }
             }
         }
@@ -66,6 +67,8 @@ namespace Paint2.Models.Figures
             IsMirrored = false;
             _parentGroup = parentGroup;
             _parentGroup.childObjects.Add(this);
+
+            Scene.Current.TriggerHeirarchyRebuild();
         }
 
         public void Export(IExportSnapshot snapshot)

--- a/ViewModels/FigureFabric.cs
+++ b/ViewModels/FigureFabric.cs
@@ -49,7 +49,7 @@ public static class FigureFabric
     public static IFigure CreateFigure(string FigureName, Group parentGroup, Point coordinates)
     {
         IFigure newFigure = info.AvailableFigures.First(f => f.Metadata.Name == FigureName).Value.Create(parentGroup, coordinates);
-        Scene.RenderedFigures.Add(new GeometryViewModel() { Figure = newFigure });
+        Scene.Current.RenderedFigures.Add(new GeometryViewModel() { Figure = newFigure });
         return newFigure;
     }
 }

--- a/ViewModels/FigureFabric.cs
+++ b/ViewModels/FigureFabric.cs
@@ -48,8 +48,6 @@ public static class FigureFabric
     public static IEnumerable<string> AvailableFigures => info.AvailableFigures.Select(f => f.Metadata.Name);
     public static IFigure CreateFigure(string FigureName, Group parentGroup, Point coordinates)
     {
-        IFigure newFigure = info.AvailableFigures.First(f => f.Metadata.Name == FigureName).Value.Create(parentGroup, coordinates);
-        Scene.Current.RenderedFigures.Add(new GeometryViewModel() { Figure = newFigure });
-        return newFigure;
+        return info.AvailableFigures.First(f => f.Metadata.Name == FigureName).Value.Create(parentGroup, coordinates);
     }
 }

--- a/ViewModels/FigureFabric.cs
+++ b/ViewModels/FigureFabric.cs
@@ -48,7 +48,8 @@ public static class FigureFabric
     public static IEnumerable<string> AvailableFigures => info.AvailableFigures.Select(f => f.Metadata.Name);
     public static IFigure CreateFigure(string FigureName, Group parentGroup, Point coordinates)
     {
-        return info.AvailableFigures.First(f => f.Metadata.Name == FigureName).Value
-            .Create(parentGroup, coordinates);
+        IFigure newFigure = info.AvailableFigures.First(f => f.Metadata.Name == FigureName).Value.Create(parentGroup, coordinates);
+        Scene.RenderedFigures.Add(new GeometryViewModel() { Figure = newFigure });
+        return newFigure;
     }
 }

--- a/ViewModels/GeometryViewModel.cs
+++ b/ViewModels/GeometryViewModel.cs
@@ -8,6 +8,5 @@ namespace Paint2.ViewModels
     public class GeometryViewModel : ViewModelBase
     {
         public required IFigure Figure { get; init; }
-        [Reactive] public required IFigureGraphicProperties Properties { get; set; }
     }
 }

--- a/ViewModels/Group.cs
+++ b/ViewModels/Group.cs
@@ -33,7 +33,7 @@ namespace Paint2.ViewModels
                     else
                     {
                         _parentGroup.childObjects.Remove(this);
-                        Scene.Current.Groups.Add(this);
+                        Scene.Current.AddGroupToRoot(this);
                         _parentGroup = null;
                     }
                 } 
@@ -41,7 +41,7 @@ namespace Paint2.ViewModels
                 {
                     if (_parentGroup is null)
                     {
-                        Scene.Current.Groups.Remove(this);
+                        Scene.Current.RemoveGroupFromRoot(this);
                         _parentGroup = value;
                         _parentGroup.childObjects.Add(this);
                     }

--- a/ViewModels/Group.cs
+++ b/ViewModels/Group.cs
@@ -57,11 +57,12 @@ namespace Paint2.ViewModels
         public Geometry Geometry { get; set; } // для группы это свойство по идеи не должно использоваться
         public bool IsActive { get; set; }
         public bool IsMirrored { get; set; }
+        public IFigureGraphicProperties GraphicProperties { get; set; }
 
         private string _name;
         private Group? _parentGroup;
 
-        public Group(string name)
+        public Group(string name, IFigureGraphicProperties graphicProperties)
         {
             _name = name;
             Coordinates = Point.Zero;
@@ -69,6 +70,7 @@ namespace Paint2.ViewModels
             childObjects = [];
             IsActive = true;
             IsMirrored = false;
+            GraphicProperties = graphicProperties;
         }
         public void Move(Point vector)
         {

--- a/ViewModels/Group.cs
+++ b/ViewModels/Group.cs
@@ -52,7 +52,7 @@ namespace Paint2.ViewModels
                         _parentGroup.childObjects.Add(this);
                     }
                 }
-                Scene.Current.TriggerHeirarchyRebuild();
+                Scene.Current.TriggerOnHeirarchyUpdate();
             }
         }
         public IList<ISceneObject> childObjects;

--- a/ViewModels/Group.cs
+++ b/ViewModels/Group.cs
@@ -30,7 +30,7 @@ namespace Paint2.ViewModels
                     else
                     {
                         _parentGroup.childObjects.Remove(this);
-                        Scene.Groups.Add(this);
+                        Scene.Current.Groups.Add(this);
                         _parentGroup = null;
                     }
                 } 
@@ -38,7 +38,7 @@ namespace Paint2.ViewModels
                 {
                     if (_parentGroup is null)
                     {
-                        Scene.Groups.Remove(this);
+                        Scene.Current.Groups.Remove(this);
                         _parentGroup = value;
                         _parentGroup.childObjects.Add(this);
                     }

--- a/ViewModels/Group.cs
+++ b/ViewModels/Group.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using Paint2.ViewModels.Utils;
 using Paint2.ViewModels.Interfaces;
 using Serilog;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System;
 
 namespace Paint2.ViewModels
 {
@@ -49,6 +52,7 @@ namespace Paint2.ViewModels
                         _parentGroup.childObjects.Add(this);
                     }
                 }
+                Scene.Current.TriggerHeirarchyRebuild();
             }
         }
         public IList<ISceneObject> childObjects;

--- a/ViewModels/HeaderPanelViewModel.cs
+++ b/ViewModels/HeaderPanelViewModel.cs
@@ -1,6 +1,7 @@
 using Avalonia.Media;
 using Avalonia.Threading;
 using Paint2.Models.Figures;
+using Paint2.ViewModels.Interfaces;
 using Paint2.ViewModels.Utils;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;

--- a/ViewModels/Interfaces/IFigure.cs
+++ b/ViewModels/Interfaces/IFigure.cs
@@ -7,6 +7,7 @@ namespace Paint2.ViewModels.Interfaces
 {
     public interface IFigure : ISceneObject
     {
+        IFigureGraphicProperties? GraphicProperties { get; set; }
         bool IsInternal(Point p, double eps);
         IFigure Intersect(IFigure other);
         IFigure Union(IFigure other);

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -30,6 +30,7 @@ public class MainWindowViewModel : ViewModelBase
     public MainWindowViewModel()
     {
         Figures = [];
+        Scene.CreateScene(Figures);
         // Пример для работы с массивом фигур
         //IFigure circle = FigureFabric.CreateFigure("Circle", new Group(""), new Dictionary<string, Point> { { "Coordinates", Point.Zero } });
         //var properties = new FigureGraphicProperties()

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -36,7 +36,7 @@ public class MainWindowViewModel : ViewModelBase
         Figures = [];
         Scene.CreateScene();
         // Подписываю Figures на обновление иерархии сцены
-        Scene.Current.OnHierarcyUpdate += UpdateFigures;
+        Scene.Current.OnHierarchyUpdate += UpdateFigures;
 
         // Пример для работы с массивом фигур
         //IFigure circle = FigureFabric.CreateFigure("Circle", new Group(""), new Dictionary<string, Point> { { "Coordinates", Point.Zero } });

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using Paint2.ViewModels.Interfaces;
 using Paint2.ViewModels.Utils;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
+using Serilog;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reactive;
@@ -29,7 +30,6 @@ public class MainWindowViewModel : ViewModelBase
     public MainWindowViewModel()
     {
         Figures = [];
-
         // Пример для работы с массивом фигур
         //IFigure circle = FigureFabric.CreateFigure("Circle", new Group(""), new Dictionary<string, Point> { { "Coordinates", Point.Zero } });
         //var properties = new FigureGraphicProperties()
@@ -40,7 +40,7 @@ public class MainWindowViewModel : ViewModelBase
         //Renderer renderer = new();
         //circle.Render(renderer);
         ////////////////////////////////////
-        
+
         HeaderPanel = new HeaderPanelViewModel(Figures);
         PropertiesPanel = new PropertiesPanelViewModel();
         GroupsPanel = new GroupsPanelViewModel();

--- a/ViewModels/Scene.cs
+++ b/ViewModels/Scene.cs
@@ -5,13 +5,18 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using static Paint2.ViewModels.Scene;
 
 namespace Paint2.ViewModels
 {
     public class Scene
     {
         public delegate void HierarchyUpdateDeligate(IList<ISceneObject> groups);
-        public HierarchyUpdateDeligate OnHierarcyUpdate;
+        public event HierarchyUpdateDeligate OnHierarchyUpdate
+        {
+            add => _onHierarcyUpdate += value;
+            remove => _onHierarcyUpdate -= value;
+        }
         public static Scene Current { get; private set; }
         // Тут хранятся все группы сцены. Корневой группы явно нет, по сути сама сцена ей является
         public IImportFormat ImportStrategy { get; set; }
@@ -19,11 +24,11 @@ namespace Paint2.ViewModels
         public IReadOnlyList<Group> Groups { get => _groups.AsReadOnly(); }
 
         private IList<Group> _groups { get; set; }
+        private HierarchyUpdateDeligate _onHierarcyUpdate;
 
         Scene()
         {
             _groups = [];
-            CreateScene();
         }
 
         // Не помню какие именно тут параметры нужны были
@@ -66,13 +71,13 @@ namespace Paint2.ViewModels
                 _groups.Remove((Group)sceneObject);
             else
                 sceneObject.Parent.childObjects.Remove(sceneObject);
-            TriggerHeirarchyRebuild();
+            TriggerOnHeirarchyUpdate();
         }
-        public void TriggerHeirarchyRebuild() => OnHierarcyUpdate.Invoke([.. _groups]);
+        public void TriggerOnHeirarchyUpdate() => _onHierarcyUpdate.Invoke([.. _groups]);
         public void ResetScene()
         {
             _groups.Clear();
-            TriggerHeirarchyRebuild();
+            TriggerOnHeirarchyUpdate();
         }
     }
 }

--- a/ViewModels/Scene.cs
+++ b/ViewModels/Scene.cs
@@ -10,17 +10,18 @@ namespace Paint2.ViewModels
 {
     public class Scene
     {
+        public delegate void HierarchyUpdateDeligate(IList<ISceneObject> groups);
+        public HierarchyUpdateDeligate OnHierarcyUpdate;
         public static Scene Current { get; private set; }
         // Тут хранятся все группы сцены. Корневой группы явно нет, по сути сама сцена ей является
         public IList<Group> Groups { get; private set; }
         public IImportFormat ImportStrategy { get; set; }
         public IExportFormat ExportStrategy { get; set; }
-        public ObservableCollection<GeometryViewModel> RenderedFigures { get; private set; }
 
-        Scene(ObservableCollection<GeometryViewModel> renderedFigures)
+        Scene()
         {
             Groups = [];
-            RenderedFigures = renderedFigures;
+            CreateScene();
         }
 
         // Не помню какие именно тут параметры нужны были
@@ -32,9 +33,9 @@ namespace Paint2.ViewModels
         {
             ImportStrategy.LoadFrom(path);
         }
-        public static void CreateScene(ObservableCollection<GeometryViewModel> renderedFigures)
+        public static void CreateScene()
         {
-            Current = new Scene(renderedFigures);
+            Current = new Scene();
         }
         public Group CreateGroup(string name, IFigureGraphicProperties graphicProperties, Group? parentGroup = null)
         {
@@ -55,15 +56,13 @@ namespace Paint2.ViewModels
                 Groups.Remove((Group)sceneObject);
             else
                 sceneObject.Parent.childObjects.Remove(sceneObject);
-
-            if (sceneObject is IFigure fig)
-            {
-                RenderedFigures.Remove(RenderedFigures.First(fig => fig.Figure == sceneObject));
-            }
+            TriggerHeirarchyRebuild();
         }
+        public void TriggerHeirarchyRebuild() => OnHierarcyUpdate.Invoke([.. Groups]);
         public void ResetScene()
         {
             Groups.Clear();
+            TriggerHeirarchyRebuild();
         }
     }
 }

--- a/ViewModels/Scene.cs
+++ b/ViewModels/Scene.cs
@@ -1,6 +1,9 @@
 ﻿using Paint2.ViewModels.Interfaces;
+using ReactiveUI;
+using ReactiveUI.Fody.Helpers;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Paint2.ViewModels
 {
@@ -10,6 +13,7 @@ namespace Paint2.ViewModels
         public static IList<Group> Groups { get; private set; }
         public static IImportFormat ImportStrategy { get; set; }
         public static IExportFormat ExportStrategy { get; set; }
+        public static ObservableCollection<GeometryViewModel> RenderedFigures { get; private set; }
 
         static Scene()
         {
@@ -25,9 +29,13 @@ namespace Paint2.ViewModels
         {
             ImportStrategy.LoadFrom(path);
         }
-        public static Group CreateGroup(string name, Group? parentGroup = null)
+        public static void SetupScene(ObservableCollection<GeometryViewModel> renderedFigures)
         {
-            Group newGroup = new(name);
+            RenderedFigures = renderedFigures;
+        }
+        public static Group CreateGroup(string name, IFigureGraphicProperties graphicProperties, Group? parentGroup = null)
+        {
+            Group newGroup = new(name, graphicProperties);
             if (parentGroup is null) // Если в топ иерархии
             {
                 Groups.Add(newGroup);

--- a/ViewModels/Scene.cs
+++ b/ViewModels/Scene.cs
@@ -14,13 +14,15 @@ namespace Paint2.ViewModels
         public HierarchyUpdateDeligate OnHierarcyUpdate;
         public static Scene Current { get; private set; }
         // Тут хранятся все группы сцены. Корневой группы явно нет, по сути сама сцена ей является
-        public IList<Group> Groups { get; private set; }
         public IImportFormat ImportStrategy { get; set; }
         public IExportFormat ExportStrategy { get; set; }
+        public IReadOnlyList<Group> Groups { get => _groups.AsReadOnly(); }
+
+        private IList<Group> _groups { get; set; }
 
         Scene()
         {
-            Groups = [];
+            _groups = [];
             CreateScene();
         }
 
@@ -42,7 +44,7 @@ namespace Paint2.ViewModels
             Group newGroup = new(name, graphicProperties);
             if (parentGroup is null) // Если в топ иерархии
             {
-                Groups.Add(newGroup);
+                _groups.Add(newGroup);
             } 
             else
             {
@@ -50,18 +52,26 @@ namespace Paint2.ViewModels
             }
             return newGroup;
         }
+        public void AddGroupToRoot(Group group)
+        {
+            Current._groups.Add(group);
+        }
+        public void RemoveGroupFromRoot(Group group)
+        {
+            Current._groups.Remove(group);
+        }
         public void RemoveObject(ISceneObject sceneObject)
         {
             if (sceneObject.Parent is null)
-                Groups.Remove((Group)sceneObject);
+                _groups.Remove((Group)sceneObject);
             else
                 sceneObject.Parent.childObjects.Remove(sceneObject);
             TriggerHeirarchyRebuild();
         }
-        public void TriggerHeirarchyRebuild() => OnHierarcyUpdate.Invoke([.. Groups]);
+        public void TriggerHeirarchyRebuild() => OnHierarcyUpdate.Invoke([.. _groups]);
         public void ResetScene()
         {
-            Groups.Clear();
+            _groups.Clear();
             TriggerHeirarchyRebuild();
         }
     }

--- a/Views/GeometryView.axaml
+++ b/Views/GeometryView.axaml
@@ -7,14 +7,14 @@
              x:Class="Paint2.Views.GeometryView"
              x:DataType="vm:GeometryViewModel"
              ClipToBounds="False">
-    <Path StrokeThickness="{Binding  Properties.BorderThickness}"
+    <Path StrokeThickness="{Binding  Figure.GraphicProperties.BorderThickness}"
           Data="{Binding Figure.Geometry}"
           PointerPressed="Path_OnPointerPressed">
         <Path.Fill>
-            <SolidColorBrush Color="{Binding Properties.SolidColor}" />
+            <SolidColorBrush Color="{Binding Figure.GraphicProperties.SolidColor}" />
         </Path.Fill>
         <Path.Stroke>
-            <SolidColorBrush Color="{Binding Properties.BorderColor}" />
+            <SolidColorBrush Color="{Binding Figure.GraphicProperties.BorderColor}" />
         </Path.Stroke>
     </Path>
 </UserControl>


### PR DESCRIPTION
Сделал сцену не статичной.
Перенес IFigureGraphicProperties внутрь фигур и групп. У фигуры IFigureGraphicProperties может быть null, тогда будет использоваться IFigureGraphicProperties из родительской группы. У группы оно null'ом быть не может.
Figures теперь автоматически обновляется при обновлении иерархии сцены. Сделано костыльно, но я не знаю как сделать лучше